### PR TITLE
Fixed the spelling of opencv-python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     python_requires = ">=3.6",
     install_requires = [
         "labgraph==2.0.0",
-        "python-opencv>=4.6.0"
+        "opencv-python>=4.6.0"
     ],
     include_package_data = True
 )


### PR DESCRIPTION
Fixed the spellling from python-opencv to opencv-python